### PR TITLE
Release CI

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,23 @@
+name: "Release Linux"
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Prepare release
+        run: ./prepare-for-release.sh
+      - name: test install-sdk
+        run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v12.10.0 && npm install && npm ci && npm run build
+        working-directory: install-sdk
+      - name: test emulator-run-cmd
+        run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v12.10.0 && npm install && npm ci && npm run build
+        working-directory: emulator-run-cmd
+      - uses: ./install-sdk
+        name: install sdk
+      - run: sdkmanager platform-tools

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -5,6 +5,11 @@ jobs:
     runs-on: macOS-10.15
     steps:
     - uses: actions/checkout@v1
+    - name: set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'adopt'
+        java-version: 11
     - name: test install-sdk
       run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v16.15.0 && npm install && npm ci && npm run build
       working-directory: install-sdk


### PR DESCRIPTION
This makes a run of `./prepare-for-release.sh` during release obsolete