### PR TITLE
Avoid parallel emulator issues by specify port number

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -36,6 +36,7 @@ jobs:
 #        abi: x86
 #        cmd: adb shell getprop
 #        bootTimeout: 500
+#        portNumber: 5555
 #    - uses: actions/upload-artifact@v4
 #      with:
 #        name: logcat
@@ -80,6 +81,7 @@ jobs:
           abi: x86
           cmd: adb shell getprop
           bootTimeout: 500
+          portNumber: 5555
       - uses: actions/upload-artifact@v4
         with:
           name: logcat-${{ matrix.os }}-${{ matrix.api }}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ steps:
 - `cmdOptions` is value which you can use to pass additional arguments to the emulator start command. By default this is `-no-snapshot-save -noaudio -no-boot-anim`
 - `disableAnimations` to disable animations using the system preferences. `false` by default. Keep in mind that applications might not respect system settings and these might have no effect at all 
 - `bootTimeout` is the emulator boot timeout (default is 600 seconds = 10 minutes)
+- `portNumber` is the emulator port number (default is 5554)
 - `verbose` if you want to enable additional logging for this action
 
 ### Artifacts

--- a/emulator-run-cmd/action.yml
+++ b/emulator-run-cmd/action.yml
@@ -26,6 +26,9 @@ inputs:
   bootTimeout:
     description: 'Boot emulator timeout (seconds)'
     default: '600'
+  portNumber:
+    description: 'emulator port number'
+    default: '5554'
   verbose:
     description: 'be verbose'
     default: 'false'

--- a/emulator-run-cmd/src/emulator.ts
+++ b/emulator-run-cmd/src/emulator.ts
@@ -26,8 +26,8 @@ export class Emulator {
         this.telnetPort = telnetPort;
     }
 
-    async start(cmdOptions: String, bootTimeout: number): Promise<Boolean> {
-        await execIgnoreFailure(`bash -c \\\"${this.sdk.emulatorCmd()} @${this.name} ${cmdOptions} &\"`)
+    async start(cmdOptions: String, bootTimeout: number, portNumber: number): Promise<Boolean> {
+        await execIgnoreFailure(`bash -c \\\"${this.sdk.emulatorCmd()} @${this.name} ${cmdOptions} -port ${portNumber} &\"`)
         let booted = await this.waitForBoot(bootTimeout);
         console.log(`booted=${booted}`)
         return booted

--- a/emulator-run-cmd/src/main.ts
+++ b/emulator-run-cmd/src/main.ts
@@ -60,7 +60,7 @@ async function run() {
         } else
             console.log(`Found portNumber=${Number(portNumber)} ${core.getInput('portNumber')}`)
 
-        console.log(`Starting emulator with API=${api}, TAG=${tag} and ABI=${abi}...`)
+        console.log(`Starting emulator with:\nAPI=${api} \nABI=${abi} \nTAG=${tag} \nVERBOSE=${verbose} \ncmd=${cmd}  \ncmdOptions=${cmdOptions} \nhardwareProfile=${hardwareProfile} \ndisableAnimations=${disableAnimations} \nbootTimeout=${bootTimeout} \nportNumber=${portNumber}\n`)
 
         const androidHome = process.env.ANDROID_HOME
         console.log(`ANDROID_HOME is ${androidHome}`)

--- a/emulator-run-cmd/src/main.ts
+++ b/emulator-run-cmd/src/main.ts
@@ -54,6 +54,12 @@ async function run() {
             bootTimeout = '720'
         }
 
+        let portNumber = core.getInput('portNumber')
+        if (portNumber == null) {
+            portNumber = "5554"
+        } else
+            console.log(`Found portNumber=${Number(portNumber)} ${core.getInput('portNumber')}`)
+
         console.log(`Starting emulator with API=${api}, TAG=${tag} and ABI=${abi}...`)
 
         const androidHome = process.env.ANDROID_HOME
@@ -72,10 +78,10 @@ async function run() {
                 return
             }
 
-            let emulator = await sdk.createEmulator("emulator", api, tag, abi, hardwareProfile);
+            let emulator = await sdk.createEmulator("emulator", api, tag, abi, hardwareProfile, Number(portNumber));
             console.log("starting adb server")
             await sdk.startAdbServer()
-            let booted = await emulator.start(cmdOptions, +bootTimeout);
+            let booted = await emulator.start(cmdOptions, +bootTimeout, Number(portNumber));
             if (!booted) {
                 core.setFailed("emulator boot failed")
                 await emulator.stop()

--- a/emulator-run-cmd/src/sdk.ts
+++ b/emulator-run-cmd/src/sdk.ts
@@ -47,6 +47,7 @@ export abstract class BaseAndroidSdk implements AndroidSDK {
         let sdkUrl: string = url
         if (sdkUrl == null || sdkUrl == "") {
             sdkUrl = this.defaultSdkUrl
+            console.log(`Android SDK URL is not set. Using default ${this.defaultSdkUrl}`)
         }
 
         if (fs.existsSync(`${process.env.HOME}/.android`)) {

--- a/emulator-run-cmd/src/sdk.ts
+++ b/emulator-run-cmd/src/sdk.ts
@@ -25,7 +25,7 @@ export interface AndroidSDK {
 
     installPlatform(api: string, verbose: boolean): Promise<any>
 
-    createEmulator(name: string, api: string, tag: string, abi: string, hardwareProfile: string): Promise<Emulator>
+    createEmulator(name: string, api: string, tag: string, abi: string, hardwareProfile: string, portNumber: number): Promise<Emulator>
 
     listEmulators(): Promise<any>
 
@@ -117,14 +117,14 @@ export abstract class BaseAndroidSdk implements AndroidSDK {
         await execIgnoreFailure(`bash -c \\\"${this.androidHome()}/cmdline-tools/latest/bin/sdkmanager 'platforms;android-${api}'${args}"`)
     }
 
-    async createEmulator(name: string, api: string, tag: string, abi: string, hardwareProfile: string): Promise<any> {
+    async createEmulator(name: string, api: string, tag: string, abi: string, hardwareProfile: string, portNumber: number): Promise<any> {
         let additionalOptions = ""
         if (hardwareProfile != null && hardwareProfile != "") {
             additionalOptions += `--device ${hardwareProfile}`
         }
 
         await execIgnoreFailure(`bash -c \\\"echo -n no | ${this.androidHome()}/cmdline-tools/latest/bin/avdmanager create avd -n ${name} --force --package \\\"system-images;android-${api};${tag};${abi}\\\" --tag ${tag}\" ${additionalOptions}`)
-        return new Emulator(this, name, api, abi, tag, this.portCounter++, this.portCounter++)
+        return new Emulator(this, name, api, abi, tag, portNumber, portNumber++)
     }
 
     async verifyHardwareAcceleration(): Promise<boolean> {

--- a/install-sdk/src/sdk.ts
+++ b/install-sdk/src/sdk.ts
@@ -25,7 +25,7 @@ export interface AndroidSDK {
 
     installPlatform(api: string, verbose: boolean): Promise<any>
 
-    createEmulator(name: string, api: string, tag: string, abi: string, hardwareProfile: string): Promise<Emulator>
+    createEmulator(name: string, api: string, tag: string, abi: string, hardwareProfile: string, portNumber: number): Promise<Emulator>
 
     listEmulators(): Promise<any>
 
@@ -121,14 +121,14 @@ export abstract class BaseAndroidSdk implements AndroidSDK {
         await execIgnoreFailure(`bash -c \\\"${this.androidHome()}/cmdline-tools/bootstrap-version/bin/sdkmanager 'platforms;android-${api}'${args}"`)
     }
 
-    async createEmulator(name: string, api: string, tag: string, abi: string, hardwareProfile: string): Promise<any> {
+    async createEmulator(name: string, api: string, tag: string, abi: string, hardwareProfile: string, portNumber: number): Promise<any> {
         let additionalOptions = ""
         if (hardwareProfile != null && hardwareProfile != "") {
             additionalOptions += `--device ${hardwareProfile}`
         }
 
         await execIgnoreFailure(`bash -c \\\"echo -n no | ${this.androidHome()}/cmdline-tools/bootstrap-version/bin/avdmanager create avd -n ${name} --force --package \\\"system-images;android-${api};${tag};${abi}\\\" --tag ${tag}\" ${additionalOptions}`)
-        return new Emulator(this, name, api, abi, tag, this.portCounter++, this.portCounter++)
+        return new Emulator(this, name, api, abi, tag, portNumber, portNumber++)
     }
 
     async verifyHardwareAcceleration(): Promise<boolean> {


### PR DESCRIPTION
This is helpful, when you have multiple runner on a self hosted M1.
Without you'll run into emulator issues during start and stop of an emulator